### PR TITLE
fix local cli entrypoint

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,11 @@ services:
     image: "extra-model-dev"
     volumes:
       - ./:/io
+    
+  extra-model:
+    <<: *dev
+    entrypoint: "extra-model"
+    command: "--help"
 
   # run all the tests and linting locally
   # - black & isort will format code to address issues

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,10 @@ RUN mkdir /io
 COPY . /io
 WORKDIR /io
 
+RUN pip install --upgrade pip wheel setuptools
+
 RUN pip install -r requirements.txt -r requirements-test.txt
+RUN pip install -e .
 
 # download nltk resources
 RUN python -m nltk.downloader wordnet

--- a/extra_model/_cli.py
+++ b/extra_model/_cli.py
@@ -7,20 +7,36 @@ import click
 from extra_model._errors import ExtraModelError
 from extra_model._run import run
 
+
 logger = logging.getLogger(__name__)
 
 
 @click.command()
-@click.argument("input_path", type=Path)
-@click.argument("output_path", type=Path, default="/app/output")
-@click.option("--debug", is_flag=True)
+@click.argument(
+    "input_path",
+    type=Path
+)
+@click.argument(
+    "output_path",
+    type=Path,
+    default="/app/output"
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    help="Enable debug logging"
+)
 def entrypoint(input_path: Path, output_path: Path, debug: bool = False) -> None:
-    """Parse and handle CLI arguments.
+    """Run the Extra algorithm for unsupervised topic extraction.
 
-    :param input_path: Path to the file that should be used for running extra_model on.
-    :param output_path: Path to the file that output of extra_model is going to be saved.
-    :param debug: If set to True, sets log level for the application to DEBUG, else WARNING.
-    :return: Dictionary with input_path and output_path set to specified values
+    INPUT_PATH is the path to the input parquet file with the user generated texts.
+    
+    OUTPUT_PATH is the path to the output directory. Default is /app/output
+    \f
+    
+    :param input_path: Path to the input parquet file.
+    :param output_path: Path to the output directory.
+    :param debug: Enable debug logging.
     """
     logging.getLogger("extra_model").setLevel("DEBUG" if debug else "INFO")
 

--- a/extra_model/_cli.py
+++ b/extra_model/_cli.py
@@ -7,36 +7,19 @@ import click
 from extra_model._errors import ExtraModelError
 from extra_model._run import run
 
-
 logger = logging.getLogger(__name__)
 
 
 @click.command()
-@click.argument(
-    "input_path",
-    type=Path
-)
-@click.argument(
-    "output_path",
-    type=Path,
-    default="/app/output"
-)
-@click.option(
-    "--debug",
-    is_flag=True,
-    help="Enable debug logging"
-)
+@click.argument("input_path", type=Path)
+@click.argument("output_path", type=Path, default="/app/output")
+@click.option("--debug", is_flag=True, help="Enable debug logging")
 def entrypoint(input_path: Path, output_path: Path, debug: bool = False) -> None:
     """Run the Extra algorithm for unsupervised topic extraction.
 
     INPUT_PATH is the path to the input parquet file with the user generated texts.
     
     OUTPUT_PATH is the path to the output directory. Default is /app/output
-    \f
-    
-    :param input_path: Path to the input parquet file.
-    :param output_path: Path to the output directory.
-    :param debug: Enable debug logging.
     """
     logging.getLogger("extra_model").setLevel("DEBUG" if debug else "INFO")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,4 +38,4 @@ exclude = "*.tests", "*.tests.*", "tests.*", "tests"
 
 [options.entry_points]
 console_scripts =
-    extra_model = extra_model._cli:entrypoint
+    extra-model = extra_model._cli:entrypoint

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+# We still need a setup.py shim so we can still pip install -e .
+# https://snarky.ca/what-the-heck-is-pyproject-toml/#how-to-use-pyproject-toml-with-setuptools
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
* cli entrypoint setup correctly
* extra can be executed via `docker-compose run --rm extra-model` and will immediately show help text
* extra should be run via `docker-compose run --rm extra-model <input file>`
  * documentation for where a user should put input file, how input file should be specified in command, where ouput will end up should be developed
  * need documentation, user story for running end-to-end with new CLI interface
