### PR TITLE
Small Dockerfile improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.github/
+.mypy_cache/
+**/__pycache__/
+cov_html/
+docs/
+tests/resources/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
+.git/
 .github/
 .mypy_cache/
 **/__pycache__/
 cov_html/
 docs/
-tests/resources/*
+io/
+site/
+tests/resources/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,11 @@ RUN python -m nltk.downloader wordnet punkt
 
 FROM python:3.8-slim-buster
 
+RUN apt-get update && apt-get install --no-install-recommends --yes \
+    curl \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /root/nltk_data /root/nltk_data
 COPY --from=builder /requirements /usr/local
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,27 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-slim-buster as builder
 
-RUN mkdir /package
-COPY . /package
-WORKDIR /package
+COPY requirements.txt requirements-test.txt ./
 
-RUN pip install --upgrade pip wheel setuptools
+RUN pip install --prefix=/requirements \
+    -r requirements.txt \
+    -r requirements-test.txt
 
-RUN pip install --use-deprecated=legacy-resolver -r requirements.txt -r requirements-test.txt
-RUN pip install --use-deprecated=legacy-resolver -e .
-
-# download nltk resources
-RUN python -m nltk.downloader wordnet
-RUN python -m nltk.downloader punkt
+ARG PYTHONPATH=/requirements/lib/python3.8/site-packages
 
 # download spacy resources
-RUN python -m spacy download en_core_web_sm
+RUN python -m spacy download en_core_web_sm --prefix=/requirements
+
+# download nltk resources
+RUN python -m nltk.downloader wordnet punkt
+
+FROM python:3.8-slim-buster
+
+COPY --from=builder /root/nltk_data /root/nltk_data
+COPY --from=builder /requirements /usr/local
+
+WORKDIR /package
+COPY . /package
+
+RUN pip install -e .
 
 CMD bash


### PR DESCRIPTION
Follow up on my last PR:

* Now that we switched to the smaller `slim-buster` image, we need to explicitly install `curl` and `unzip`, which are necessary for downloading embeddings
* Update the dockerfile to use a multistage build. This marginally decreases image size (1.4GB to 1.1GB, excluding embeddings) and build time (2:40 -> 2:07 minutes, excluding embeddings)
* Added a few directories to the `.dockerignore` file and moved the `COPY . /package` step to the _end_ of the Dockerfile, which drastically speeds up the process of rebuilding the Docker image, as you only need to fully rebuild the image when the Dockerfile or requirements files are updated.