### PR TITLE
Adding embedding path as an option argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `cytoolz` dependency not used by `extra-model`
 - Updated from using `pycld2` to `pycld3`
+- Added fourth positional command line argument to specify the path to the embeddings
 
 ## [0.2.0] 2021-03-17
 

--- a/docs/running_extra.md
+++ b/docs/running_extra.md
@@ -58,6 +58,12 @@ The output filename can also be changed if you want it to be something else than
 docker-compose run extra-model /package/tests/resources/100_comments.csv /io/another_folder another_filename.csv
 ```
 
+The location of the embeddings can also be changed from `./embeddings` by supplying a fourth argument:
+
+```bash
+docker-compose run extra-model /package/tests/resources/100_comments.csv /io/another_folder another_filename.csv path/to/embeddings
+```
+
 ### Using command line
 
 #### Install `extra-model`

--- a/extra_model/_cli.py
+++ b/extra_model/_cli.py
@@ -13,16 +13,21 @@ logger = logging.getLogger(__name__)
 
 OUTPUT_PATH = "/io"
 OUTPUT_FILENAME = "result.csv"
-EMBEDDINGS_PATH = "/embeddings"
+EMBEDDINGS_PATH = "./embeddings"
 
 
 @click.command()
 @click.argument("input_path", type=Path)
 @click.argument("output_path", type=Path, default=OUTPUT_PATH)
 @click.argument("output_filename", type=Path, default=OUTPUT_FILENAME)
+@click.argument("embeddings_path", type=Path, default=EMBEDDINGS_PATH)
 @click.option("--debug", is_flag=True, help="Enable debug logging")
 def entrypoint(
-    input_path: Path, output_path: Path, output_filename: Path, debug: bool = False
+    input_path: Path,
+    output_path: Path,
+    output_filename: Path,
+    embeddings_path: Path,
+    debug: bool = False,
 ) -> None:
     """Run the Extra algorithm for unsupervised topic extraction.
 
@@ -32,11 +37,14 @@ def entrypoint(
 
     OUTPUT_FILENAME is the filename of the output file. Default is `result.csv`.
     The `.csv` file extension is not enforced. Please take care of this accordingly.
+
+    EMBEDDINGS_PATH is the path where the extra model will load the embeddings from.
+    defaults to `./embeddings`.
     """
     logging.getLogger("extra_model").setLevel("DEBUG" if debug else "INFO")
 
     try:
-        run(input_path, output_path, output_filename)
+        run(input_path, output_path, output_filename, embeddings_path)
         sys.exit(0)
 
     except ExtraModelError as e:

--- a/extra_model/_run.py
+++ b/extra_model/_run.py
@@ -5,19 +5,22 @@ import pandas as pd
 
 from extra_model._models import ExtraModel
 
-MODELS_FOLDER = "./embeddings"
+MODELS_FOLDER = Path("./embeddings")
 OUTPUT_FILE = Path("result.csv")
 
 logger = logging.getLogger(__name__)
 
 
 def run(
-    input_path: Path, output_path: Path, output_filename: Path = OUTPUT_FILE
+    input_path: Path,
+    output_path: Path,
+    output_filename: Path = OUTPUT_FILE,
+    embeddings_path: Path = MODELS_FOLDER,
 ) -> None:
     """Docstring."""
     logging.basicConfig(format="  %(message)s")
 
-    extra_model = ExtraModel(models_folder=MODELS_FOLDER)
+    extra_model = ExtraModel(models_folder=embeddings_path)
     extra_model.load_from_files()
 
     logger.info(f"Loading data from {input_path}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,7 @@ def setup_mock(mocker):
 INPUT = "/input"
 OUTPUT = "/output"
 OUTPUT_FILENAME = "result.csv"
+EMBEDDINGS_PATH = "./embeddings"
 
 
 def test_entrypoint__run_raises_no_exception__exit_code_0(cli_runner, run_mock):
@@ -68,7 +69,9 @@ def test_entrypoint__input_and_output_path_set__arguments_passed_to_run(
         entrypoint, [INPUT, OUTPUT, OUTPUT_FILENAME], catch_exceptions=False
     )
 
-    run_mock.assert_called_once_with(Path(INPUT), Path(OUTPUT), Path(OUTPUT_FILENAME))
+    run_mock.assert_called_once_with(
+        Path(INPUT), Path(OUTPUT), Path(OUTPUT_FILENAME), Path(EMBEDDINGS_PATH)
+    )
 
 
 def test_entrypoint_setup__setup_raises_no_exception__exit_code_0(


### PR DESCRIPTION
Closes #56

- Changes `EMBEDDINGS_PATH ` to point to `./embeddings`
- Passes this argument to `_run.py::run`