### PR TITLE
Update dependabot config to include docker and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Description

- `Dependabot` helps you keep your dependencies up to date
- `Depedanbot` needs to be configured across various stacks we use in a repo
- This repo is using `python` (`pip` for dependencies), `docker` and `github-actions`
- Currently in the repo `dependabot` is only configured to keep `python` (`pip`) dependencies up to date, this PR updates the config to keep `docker` and `github-actions` dependencies also up to date.