### PR TITLE
Replacing cld3 with langdetect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated all versions to the latest available (courtesy of `dependabot`)
 - Added `run_from_dataframe` in `_run.py`, which enables passing dataframe as an input
 - Dropped Python 3.7 support (i.e., we no longer test for this version) since `numpy` dropped it
+- Replaced `pycld3` with `langdetect`. `pycld3` is unlikely to be supported in 3.10 and it recently started failing to build in 3.9. Since `pycld3` was only used in one place and given that `langdetect` looks like a reasonable replacement, we've decided to replace it.
 
 ### Fixed
 - an update to scipy exposed an issue in rare cases in disambiguation, where choice of meaning for contextless aspects 

--- a/extra_model/_filter.py
+++ b/extra_model/_filter.py
@@ -1,6 +1,6 @@
 import logging
 
-import cld3
+import langdetect
 import pandas as pd
 
 logger = logging.getLogger(__name__)
@@ -38,9 +38,9 @@ def filter(dataframe):
     # detect language and filter english. If it's 'unknown' it's probably
     # still english
     dataframe.loc[:, "lang"] = dataframe.Comments.apply(
-        lambda com: cld3.get_language(com).language
+        lambda com: langdetect.detect(com)
     )
-    dataframe = dataframe[(dataframe["lang"] == "en") | (dataframe["lang"] == "un")]
+    dataframe = dataframe[(dataframe["lang"] == "en")]
 
     # drop auxiliary columns again, re-index
     dataframe.drop(["cl", "lang"], axis="columns", inplace=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ nltk==3.7
 scikit-learn==1.1.2
 vaderSentiment==3.3.2
 pandas==1.4.4
-pycld3==0.22
+langdetect==1.0.9
 networkx==2.8.6
 gensim==4.2.0
 scipy==1.9.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     scikit-learn==1.1.2
     vaderSentiment==3.3.2
     pandas==1.4.4
-    pycld3==0.22
+    langdetect==1.0.9
     networkx==2.8.6
     gensim==4.2.0
     scipy==1.9.1


### PR DESCRIPTION
`pycld3` is not actively maintained and it recently started to fail when building it in 3.9. Since it is only used in one place, I've decide to replace it with a more lightweight tool that seems to be doing a good enough job.