### PR TITLE
Add missing dependency for mkdocstrings python handler

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,3 +12,4 @@ pydocstyle==6.1.1
 mkdocs==1.3.1
 mkdocstrings==0.19.0
 mkdocs-material==8.4.2
+mkdocstrings-python==0.7.1


### PR DESCRIPTION
add missing dependency for mkdocstrings python handler